### PR TITLE
Modifications to GrapPA objective

### DIFF
--- a/mlreco/models/grappa.py
+++ b/mlreco/models/grappa.py
@@ -1,4 +1,3 @@
-from operator import xor
 import random
 import torch
 import numpy as np

--- a/mlreco/models/grappa.py
+++ b/mlreco/models/grappa.py
@@ -347,7 +347,7 @@ class GNN(torch.nn.Module):
         # Add start point and/or start direction to node features if requested
         if self.add_start_point or points is not None:
             if points is None:
-                points = get_cluster_points_label(cluster_data, particles, clusts, self.source_col==6, coords_index=self.coords_index)
+                points = get_cluster_points_label(cluster_data, particles, clusts, coords_index=self.coords_index)
             x = torch.cat([x, points.float()], dim=1)
             if self.add_start_dir:
                 dirs = get_cluster_directions(cluster_data[:, self.coords_index[0]:self.coords_index[1]], points[:,:3], clusts, self.start_dir_max_dist, self.start_dir_opt)

--- a/mlreco/models/layers/gnn/losses/node_type.py
+++ b/mlreco/models/layers/gnn/losses/node_type.py
@@ -84,10 +84,9 @@ class NodeTypeLoss(torch.nn.Module):
                 node_assn = get_cluster_label(labels, clusts, column=self.target_col)
                 node_assn = torch.tensor(node_assn, dtype=torch.long, device=node_pred.device, requires_grad=False)
 
-                # Do not apply loss to nodes labeled -1 (unknown class)
+                # If a cluster target is -1, ignore the loss associated with it
                 node_mask = torch.nonzero(node_assn > -1, as_tuple=True)[0]
-                if not len(node_mask):
-                    continue
+                if not len(node_mask): continue
                 node_pred = node_pred[node_mask]
                 node_assn = node_assn[node_mask]
 


### PR DESCRIPTION
Changed the GrapPA losses to ignore the loss computed for nodes that have an undefined target (-1) and to ignore the loss of all edges associated with it. 

This PR also includes a modification to the standalone GrapPA that enforces 6 "end points" features for all classes, so that the standalone GrapPA weights can be transferred to the full chain.